### PR TITLE
Fixed small typo in the description of cachemean in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ really a list containing a function to
 
 The following function calculates the mean of the special "vector"
 created with the above function. However, it first checks to see if the
-mean has already been calculated. If so, it `get`s the mean from the
+mean has already been calculated. If so, it `gets` the mean from the
 cache and skips the computation. Otherwise, it calculates the mean of
 the data and sets the value of the mean in the cache via the `setmean`
 function.

--- a/cachematrix.R
+++ b/cachematrix.R
@@ -4,12 +4,30 @@
 ## Write a short comment describing this function
 
 makeCacheMatrix <- function(x = matrix()) {
-
+  m <- NULL
+  set <- function(y) {
+    x <<- y
+    m <<- NULL
+  }
+  get <- function() x
+  setinverse <- function(inv) m <<- inv
+  getinverse <- function() m
+  list(set = set, get = get,
+       setinverse = setinverse,
+       getinverse = getinverse)
 }
 
 
 ## Write a short comment describing this function
 
 cacheSolve <- function(x, ...) {
-        ## Return a matrix that is the inverse of 'x'
+  m <- x$getinverse()
+  if(!is.null(m)) {
+    message("getting cached data")
+    return(m)
+  }
+  data <- x$get()
+  m <- solve(data, ...)
+  x$setinverse(m)
+  m
 }


### PR DESCRIPTION
The formatting looks funny in the description of the cachemean function in the README file. This might be on purpose, if not this changes it!
