### PR TITLE
Removed the ellipse from signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ cache and skips the computation. Otherwise, it calculates the mean of
 the data and sets the value of the mean in the cache via the `setmean`
 function.
 
-    cachemean <- function(x, ...) {
+    cachemean <- function(x) {
             m <- x$getmean()
             if(!is.null(m)) {
                     message("getting cached data")
                     return(m)
             }
             data <- x$get()
-            m <- mean(data, ...)
+            m <- mean(data)
             x$setmean(m)
             m
     }


### PR DESCRIPTION
You pass the parameters to mean() function but you don't store them. So, when you call the function with different parameters, instead of recalculating the mean you pull it from the cache. If you call mean with or without NA removing, you'll get incorrect results using this cached mean method. Therefore, it's better to remove the ellipse. 

Alternatively you could implement handling of parameter changes but that' more code and is not related to the subject of this example.
